### PR TITLE
Add interactive keyboard layout reference page

### DIFF
--- a/app/keyboards/page.tsx
+++ b/app/keyboards/page.tsx
@@ -1,0 +1,1211 @@
+"use client";
+
+import clsx from "clsx";
+import { useEffect, useState } from "react";
+
+type KeyVariant = "wide" | "extraWide" | "space" | "tall";
+
+type KeyCategory = "modifier" | "function" | "neutral";
+
+type KeyDefinition = {
+  kind: "key";
+  label: string;
+  variant?: KeyVariant;
+  category?: KeyCategory;
+  osLabel?: {
+    win: string;
+    mac: string;
+  };
+  macSymbol?: string;
+  matches: string[];
+  colSpan?: number;
+  rowSpan?: number;
+};
+
+type SpacerDefinition = {
+  kind: "gap";
+  size?: "sm" | "md" | "lg";
+};
+
+type ArrowClusterDefinition = {
+  kind: "arrows";
+};
+
+type KeySpec = KeyDefinition | SpacerDefinition | ArrowClusterDefinition;
+
+type LayoutSection = {
+  rows: KeySpec[][];
+};
+
+type NumpadSection = {
+  grid: KeyDefinition[];
+};
+
+type KeyboardLayout = {
+  id: string;
+  title: string;
+  main: LayoutSection;
+  control?: LayoutSection;
+  numpad?: NumpadSection;
+  className?: string;
+};
+
+const gapClasses: Record<NonNullable<SpacerDefinition["size"]>, string> = {
+  sm: "w-2",
+  md: "w-4",
+  lg: "w-6",
+};
+
+const variantClasses: Record<KeyVariant, string> = {
+  wide: "min-w-[60px]",
+  extraWide: "min-w-[90px]",
+  space: "min-w-[220px]",
+  tall: "h-[88px]",
+};
+
+const categoryClasses: Record<KeyCategory, string> = {
+  neutral: "bg-slate-900/70 text-slate-100 border-slate-700/80 hover:border-slate-500",
+  modifier: "bg-slate-800/70 text-slate-100 border-slate-700/80 hover:border-slate-500",
+  function: "bg-slate-800/60 text-slate-200 border-slate-700/80 hover:border-slate-500",
+};
+
+const specialMatchMap: Record<string, string[]> = {
+  "1": ["!"],
+  "2": ["@"],
+  "3": ["#"],
+  "4": ["$"],
+  "5": ["%"],
+  "6": ["^"],
+  "7": ["&"],
+  "8": ["*"],
+  "9": ["("],
+  "0": [")"],
+  "-": ["_"],
+  "=": ["+"],
+  "[": ["{"],
+  "]": ["}"],
+  "\\": ["|"],
+  ";": [":"],
+  "'": ['"'],
+  ",": ["<"],
+  ".": [">"],
+  "/": ["?"],
+  "~": ["`"],
+};
+
+const createKey = (
+  label: string,
+  options: Omit<
+    KeyDefinition,
+    "kind" | "label" | "matches" | "category"
+  > & { matches?: string[]; category?: KeyCategory } = {}
+): KeyDefinition => {
+  const normalizedLabel = label.replace(/\s+/g, "").toUpperCase();
+  const baseMatches = new Set<string>([normalizedLabel]);
+
+  const specialMatches = specialMatchMap[label];
+  if (specialMatches) {
+    specialMatches.forEach((match) => baseMatches.add(match.toUpperCase()));
+  }
+
+  if (options.osLabel?.mac) {
+    baseMatches.add(options.osLabel.mac.replace(/\s+/g, "").toUpperCase());
+  }
+  if (options.osLabel?.win) {
+    baseMatches.add(options.osLabel.win.replace(/\s+/g, "").toUpperCase());
+  }
+
+  options.matches?.forEach((match) => {
+    baseMatches.add(match.replace(/\s+/g, "").toUpperCase());
+  });
+
+  return {
+    kind: "key",
+    label,
+    variant: options.variant,
+    category: options.category ?? "neutral",
+    matches: Array.from(baseMatches),
+    osLabel: options.osLabel,
+    macSymbol: options.macSymbol,
+    colSpan: options.colSpan,
+    rowSpan: options.rowSpan,
+  };
+};
+
+const gap = (size: SpacerDefinition["size"] = "md"): SpacerDefinition => ({
+  kind: "gap",
+  size,
+});
+
+const arrowCluster = (): ArrowClusterDefinition => ({
+  kind: "arrows",
+});
+
+const arrowKeys = {
+  up: createKey("↑", { matches: ["ArrowUp"] }),
+  down: createKey("↓", { matches: ["ArrowDown"] }),
+  left: createKey("←", { matches: ["ArrowLeft"] }),
+  right: createKey("→", { matches: ["ArrowRight"] }),
+};
+
+const layouts: KeyboardLayout[] = [
+  {
+    id: "full",
+    title: "100% 布局 (104/108 键)",
+    main: {
+      rows: [
+        [
+          createKey("Esc", { matches: ["Escape"], category: "function" }),
+          gap("lg"),
+          createKey("F1", { category: "function" }),
+          createKey("F2", { category: "function" }),
+          createKey("F3", { category: "function" }),
+          createKey("F4", { category: "function" }),
+          gap("lg"),
+          createKey("F5", { category: "function" }),
+          createKey("F6", { category: "function" }),
+          createKey("F7", { category: "function" }),
+          createKey("F8", { category: "function" }),
+          gap("lg"),
+          createKey("F9", { category: "function" }),
+          createKey("F10", { category: "function" }),
+          createKey("F11", { category: "function" }),
+          createKey("F12", { category: "function" }),
+        ],
+        [
+          createKey("~"),
+          createKey("1"),
+          createKey("2"),
+          createKey("3"),
+          createKey("4"),
+          createKey("5"),
+          createKey("6"),
+          createKey("7"),
+          createKey("8"),
+          createKey("9"),
+          createKey("0"),
+          createKey("-"),
+          createKey("="),
+          createKey("Backspace", { variant: "wide", matches: ["Backspace"] }),
+        ],
+        [
+          createKey("Tab", { variant: "wide", matches: ["Tab"] }),
+          createKey("Q"),
+          createKey("W"),
+          createKey("E"),
+          createKey("R"),
+          createKey("T"),
+          createKey("Y"),
+          createKey("U"),
+          createKey("I"),
+          createKey("O"),
+          createKey("P"),
+          createKey("["),
+          createKey("]"),
+          createKey("\\"),
+        ],
+        [
+          createKey("Caps Lock", {
+            variant: "extraWide",
+            matches: ["CapsLock"],
+          }),
+          createKey("A"),
+          createKey("S"),
+          createKey("D"),
+          createKey("F"),
+          createKey("G"),
+          createKey("H"),
+          createKey("J"),
+          createKey("K"),
+          createKey("L"),
+          createKey(";"),
+          createKey("'"),
+          createKey("Enter", { variant: "extraWide", matches: ["Enter", "Return"] }),
+        ],
+        [
+          createKey("Shift", { variant: "extraWide", matches: ["Shift"] }),
+          createKey("Z"),
+          createKey("X"),
+          createKey("C"),
+          createKey("V"),
+          createKey("B"),
+          createKey("N"),
+          createKey("M"),
+          createKey(","),
+          createKey("."),
+          createKey("/"),
+          createKey("Shift", { variant: "extraWide", matches: ["Shift"] }),
+        ],
+        [
+          createKey("Ctrl", {
+            variant: "wide",
+            category: "modifier",
+            matches: ["Control"],
+          }),
+          createKey("Win", {
+            variant: "wide",
+            category: "modifier",
+            osLabel: { win: "Win", mac: "Cmd" },
+            macSymbol: "⌘",
+            matches: ["Meta", "OS", "Command"],
+          }),
+          createKey("Alt", {
+            variant: "wide",
+            category: "modifier",
+            osLabel: { win: "Alt", mac: "Option" },
+            macSymbol: "⌥",
+            matches: ["Option"],
+          }),
+          createKey("Space", {
+            variant: "space",
+            matches: ["Space"],
+          }),
+          createKey("Alt", {
+            variant: "wide",
+            category: "modifier",
+            osLabel: { win: "Alt", mac: "Option" },
+            macSymbol: "⌥",
+            matches: ["Option"],
+          }),
+          createKey("Win", {
+            variant: "wide",
+            category: "modifier",
+            osLabel: { win: "Win", mac: "Cmd" },
+            macSymbol: "⌘",
+            matches: ["Meta", "OS", "Command"],
+          }),
+          createKey("Fn", { variant: "wide", category: "function" }),
+          createKey("Ctrl", {
+            variant: "wide",
+            category: "modifier",
+            matches: ["Control"],
+          }),
+        ],
+      ],
+    },
+    control: {
+      rows: [
+        [
+          createKey("Print", { matches: ["PrintScreen"] }),
+          createKey("Scroll", { matches: ["ScrollLock"] }),
+          createKey("Pause", { matches: ["Pause", "Break"] }),
+        ],
+        [
+          createKey("Insert"),
+          createKey("Home"),
+          createKey("PgUp", { matches: ["PageUp"] }),
+        ],
+        [
+          createKey("Delete"),
+          createKey("End"),
+          createKey("PgDn", { matches: ["PageDown"] }),
+        ],
+        [arrowCluster()],
+      ],
+    },
+    numpad: {
+      grid: [
+        createKey("Num", { matches: ["NumLock"] }),
+        createKey("/", { matches: ["Divide"] }),
+        createKey("*", { matches: ["Multiply"] }),
+        createKey("-", { matches: ["Subtract"] }),
+        createKey("7"),
+        createKey("8"),
+        createKey("9"),
+        createKey("+", { rowSpan: 2, matches: ["Add"] }),
+        createKey("4"),
+        createKey("5"),
+        createKey("6"),
+        createKey("1"),
+        createKey("2"),
+        createKey("3"),
+        createKey("Enter", { rowSpan: 2, matches: ["Enter", "Return"] }),
+        createKey("0", { colSpan: 2 }),
+        createKey("."),
+      ],
+    },
+  },
+  {
+    id: "ninetyfive",
+    title: "95% 布局 (96/98 键)",
+    className: "lg:flex-row lg:justify-between",
+    main: {
+      rows: [
+        [
+          createKey("Esc", { matches: ["Escape"], category: "function" }),
+          gap("lg"),
+          createKey("F1", { category: "function" }),
+          createKey("F2", { category: "function" }),
+          createKey("F3", { category: "function" }),
+          createKey("F4", { category: "function" }),
+          gap("lg"),
+          createKey("F5", { category: "function" }),
+          createKey("F6", { category: "function" }),
+          createKey("F7", { category: "function" }),
+          createKey("F8", { category: "function" }),
+          gap("lg"),
+          createKey("F9", { category: "function" }),
+          createKey("F10", { category: "function" }),
+          createKey("F11", { category: "function" }),
+          createKey("F12", { category: "function" }),
+        ],
+        [
+          createKey("~"),
+          createKey("1"),
+          createKey("2"),
+          createKey("3"),
+          createKey("4"),
+          createKey("5"),
+          createKey("6"),
+          createKey("7"),
+          createKey("8"),
+          createKey("9"),
+          createKey("0"),
+          createKey("-"),
+          createKey("="),
+          createKey("Backspace", { variant: "wide", matches: ["Backspace"] }),
+        ],
+        [
+          createKey("Tab", { variant: "wide" }),
+          createKey("Q"),
+          createKey("W"),
+          createKey("E"),
+          createKey("R"),
+          createKey("T"),
+          createKey("Y"),
+          createKey("U"),
+          createKey("I"),
+          createKey("O"),
+          createKey("P"),
+          createKey("["),
+          createKey("]"),
+          createKey("\\"),
+        ],
+        [
+          createKey("Caps Lock", { variant: "extraWide", matches: ["CapsLock"] }),
+          createKey("A"),
+          createKey("S"),
+          createKey("D"),
+          createKey("F"),
+          createKey("G"),
+          createKey("H"),
+          createKey("J"),
+          createKey("K"),
+          createKey("L"),
+          createKey(";"),
+          createKey("'"),
+          createKey("Enter", { variant: "extraWide", matches: ["Enter", "Return"] }),
+        ],
+        [
+          createKey("Shift", { variant: "extraWide", matches: ["Shift"] }),
+          createKey("Z"),
+          createKey("X"),
+          createKey("C"),
+          createKey("V"),
+          createKey("B"),
+          createKey("N"),
+          createKey("M"),
+          createKey(","),
+          createKey("."),
+          createKey("/"),
+          createKey("Shift", { variant: "extraWide", matches: ["Shift"] }),
+        ],
+        [
+          createKey("Ctrl", { variant: "wide", category: "modifier", matches: ["Control"] }),
+          createKey("Win", {
+            variant: "wide",
+            category: "modifier",
+            osLabel: { win: "Win", mac: "Cmd" },
+            macSymbol: "⌘",
+            matches: ["Meta", "OS", "Command"],
+          }),
+          createKey("Alt", {
+            variant: "wide",
+            category: "modifier",
+            osLabel: { win: "Alt", mac: "Option" },
+            macSymbol: "⌥",
+            matches: ["Option"],
+          }),
+          createKey("Space", { variant: "space", matches: ["Space"] }),
+          createKey("Alt", {
+            variant: "wide",
+            category: "modifier",
+            osLabel: { win: "Alt", mac: "Option" },
+            macSymbol: "⌥",
+            matches: ["Option"],
+          }),
+          createKey("Win", {
+            variant: "wide",
+            category: "modifier",
+            osLabel: { win: "Win", mac: "Cmd" },
+            macSymbol: "⌘",
+            matches: ["Meta", "OS", "Command"],
+          }),
+          createKey("Fn", { variant: "wide", category: "function" }),
+          createKey("Ctrl", { variant: "wide", category: "modifier", matches: ["Control"] }),
+        ],
+      ],
+    },
+    numpad: {
+      grid: [
+        createKey("Num", { matches: ["NumLock"] }),
+        createKey("/", { matches: ["Divide"] }),
+        createKey("*", { matches: ["Multiply"] }),
+        createKey("-", { matches: ["Subtract"] }),
+        createKey("7"),
+        createKey("8"),
+        createKey("9"),
+        createKey("+", { rowSpan: 2, matches: ["Add"] }),
+        createKey("4"),
+        createKey("5"),
+        createKey("6"),
+        createKey("1"),
+        createKey("2"),
+        createKey("3"),
+        createKey("Enter", { rowSpan: 2, matches: ["Enter", "Return"] }),
+        createKey("0", { colSpan: 2 }),
+        createKey("."),
+      ],
+    },
+  },
+  {
+    id: "tkl",
+    title: "80% 布局 (87 键)",
+    className: "lg:flex-row lg:justify-between",
+    main: {
+      rows: [
+        [
+          createKey("Esc", { matches: ["Escape"], category: "function" }),
+          gap("lg"),
+          createKey("F1", { category: "function" }),
+          createKey("F2", { category: "function" }),
+          createKey("F3", { category: "function" }),
+          createKey("F4", { category: "function" }),
+          gap("lg"),
+          createKey("F5", { category: "function" }),
+          createKey("F6", { category: "function" }),
+          createKey("F7", { category: "function" }),
+          createKey("F8", { category: "function" }),
+          gap("lg"),
+          createKey("F9", { category: "function" }),
+          createKey("F10", { category: "function" }),
+          createKey("F11", { category: "function" }),
+          createKey("F12", { category: "function" }),
+        ],
+        [
+          createKey("~"),
+          createKey("1"),
+          createKey("2"),
+          createKey("3"),
+          createKey("4"),
+          createKey("5"),
+          createKey("6"),
+          createKey("7"),
+          createKey("8"),
+          createKey("9"),
+          createKey("0"),
+          createKey("-"),
+          createKey("="),
+          createKey("Backspace", { variant: "wide", matches: ["Backspace"] }),
+        ],
+        [
+          createKey("Tab", { variant: "wide" }),
+          createKey("Q"),
+          createKey("W"),
+          createKey("E"),
+          createKey("R"),
+          createKey("T"),
+          createKey("Y"),
+          createKey("U"),
+          createKey("I"),
+          createKey("O"),
+          createKey("P"),
+          createKey("["),
+          createKey("]"),
+          createKey("\\"),
+        ],
+        [
+          createKey("Caps Lock", { variant: "extraWide", matches: ["CapsLock"] }),
+          createKey("A"),
+          createKey("S"),
+          createKey("D"),
+          createKey("F"),
+          createKey("G"),
+          createKey("H"),
+          createKey("J"),
+          createKey("K"),
+          createKey("L"),
+          createKey(";"),
+          createKey("'"),
+          createKey("Enter", { variant: "extraWide", matches: ["Enter", "Return"] }),
+        ],
+        [
+          createKey("Shift", { variant: "extraWide", matches: ["Shift"] }),
+          createKey("Z"),
+          createKey("X"),
+          createKey("C"),
+          createKey("V"),
+          createKey("B"),
+          createKey("N"),
+          createKey("M"),
+          createKey(","),
+          createKey("."),
+          createKey("/"),
+          createKey("Shift", { variant: "extraWide", matches: ["Shift"] }),
+        ],
+        [
+          createKey("Ctrl", { variant: "wide", category: "modifier", matches: ["Control"] }),
+          createKey("Win", {
+            variant: "wide",
+            category: "modifier",
+            osLabel: { win: "Win", mac: "Cmd" },
+            macSymbol: "⌘",
+            matches: ["Meta", "OS", "Command"],
+          }),
+          createKey("Alt", {
+            variant: "wide",
+            category: "modifier",
+            osLabel: { win: "Alt", mac: "Option" },
+            macSymbol: "⌥",
+            matches: ["Option"],
+          }),
+          createKey("Space", { variant: "space", matches: ["Space"] }),
+          createKey("Alt", {
+            variant: "wide",
+            category: "modifier",
+            osLabel: { win: "Alt", mac: "Option" },
+            macSymbol: "⌥",
+            matches: ["Option"],
+          }),
+          createKey("Win", {
+            variant: "wide",
+            category: "modifier",
+            osLabel: { win: "Win", mac: "Cmd" },
+            macSymbol: "⌘",
+            matches: ["Meta", "OS", "Command"],
+          }),
+          createKey("Fn", { variant: "wide", category: "function" }),
+          createKey("Ctrl", { variant: "wide", category: "modifier", matches: ["Control"] }),
+        ],
+      ],
+    },
+    control: {
+      rows: [
+        [
+          createKey("Print", { matches: ["PrintScreen"] }),
+          createKey("Scroll", { matches: ["ScrollLock"] }),
+          createKey("Pause", { matches: ["Pause", "Break"] }),
+        ],
+        [
+          createKey("Insert"),
+          createKey("Home"),
+          createKey("PgUp", { matches: ["PageUp"] }),
+        ],
+        [
+          createKey("Delete"),
+          createKey("End"),
+          createKey("PgDn", { matches: ["PageDown"] }),
+        ],
+        [arrowCluster()],
+      ],
+    },
+  },
+  {
+    id: "seventyfive",
+    title: "75% 布局 (84/86 键)",
+    main: {
+      rows: [
+        [
+          createKey("Esc", { matches: ["Escape"], category: "function" }),
+          createKey("F1", { category: "function" }),
+          createKey("F2", { category: "function" }),
+          createKey("F3", { category: "function" }),
+          createKey("F4", { category: "function" }),
+          createKey("F5", { category: "function" }),
+          createKey("F6", { category: "function" }),
+          createKey("F7", { category: "function" }),
+          createKey("F8", { category: "function" }),
+          createKey("F9", { category: "function" }),
+          createKey("F10", { category: "function" }),
+          createKey("F11", { category: "function" }),
+          createKey("F12", { category: "function" }),
+          createKey("Del", { matches: ["Delete"] }),
+        ],
+        [
+          createKey("~"),
+          createKey("1"),
+          createKey("2"),
+          createKey("3"),
+          createKey("4"),
+          createKey("5"),
+          createKey("6"),
+          createKey("7"),
+          createKey("8"),
+          createKey("9"),
+          createKey("0"),
+          createKey("-"),
+          createKey("="),
+          createKey("Backspace", { variant: "wide", matches: ["Backspace"] }),
+        ],
+        [
+          createKey("Tab", { variant: "wide" }),
+          createKey("Q"),
+          createKey("W"),
+          createKey("E"),
+          createKey("R"),
+          createKey("T"),
+          createKey("Y"),
+          createKey("U"),
+          createKey("I"),
+          createKey("O"),
+          createKey("P"),
+          createKey("["),
+          createKey("]"),
+          createKey("\\"),
+          createKey("PgUp", { matches: ["PageUp"] }),
+        ],
+        [
+          createKey("Caps Lock", { variant: "extraWide", matches: ["CapsLock"] }),
+          createKey("A"),
+          createKey("S"),
+          createKey("D"),
+          createKey("F"),
+          createKey("G"),
+          createKey("H"),
+          createKey("J"),
+          createKey("K"),
+          createKey("L"),
+          createKey(";"),
+          createKey("'"),
+          createKey("Enter", { variant: "extraWide", matches: ["Enter", "Return"] }),
+          createKey("PgDn", { matches: ["PageDown"] }),
+        ],
+        [
+          createKey("Shift", { variant: "extraWide", matches: ["Shift"] }),
+          createKey("Z"),
+          createKey("X"),
+          createKey("C"),
+          createKey("V"),
+          createKey("B"),
+          createKey("N"),
+          createKey("M"),
+          createKey(","),
+          createKey("."),
+          createKey("/"),
+          createKey("Shift", { variant: "wide", matches: ["Shift"] }),
+          createKey("↑", { matches: ["ArrowUp"] }),
+          createKey("End"),
+        ],
+        [
+          createKey("Ctrl", { variant: "wide", category: "modifier", matches: ["Control"] }),
+          createKey("Win", {
+            variant: "wide",
+            category: "modifier",
+            osLabel: { win: "Win", mac: "Cmd" },
+            macSymbol: "⌘",
+            matches: ["Meta", "OS", "Command"],
+          }),
+          createKey("Alt", {
+            variant: "wide",
+            category: "modifier",
+            osLabel: { win: "Alt", mac: "Option" },
+            macSymbol: "⌥",
+            matches: ["Option"],
+          }),
+          createKey("Space", { variant: "space", matches: ["Space"] }),
+          createKey("Alt", {
+            variant: "wide",
+            category: "modifier",
+            osLabel: { win: "Alt", mac: "Option" },
+            macSymbol: "⌥",
+            matches: ["Option"],
+          }),
+          createKey("Win", {
+            variant: "wide",
+            category: "modifier",
+            osLabel: { win: "Win", mac: "Cmd" },
+            macSymbol: "⌘",
+            matches: ["Meta", "OS", "Command"],
+          }),
+          createKey("Fn", { variant: "wide", category: "function" }),
+          createKey("Ctrl", { variant: "wide", category: "modifier", matches: ["Control"] }),
+        ],
+      ],
+    },
+  },
+  {
+    id: "sixtyfive",
+    title: "65% 布局 (68 键)",
+    main: {
+      rows: [
+        [
+          createKey("~"),
+          createKey("1"),
+          createKey("2"),
+          createKey("3"),
+          createKey("4"),
+          createKey("5"),
+          createKey("6"),
+          createKey("7"),
+          createKey("8"),
+          createKey("9"),
+          createKey("0"),
+          createKey("-"),
+          createKey("="),
+          createKey("Backspace", { variant: "wide", matches: ["Backspace"] }),
+          createKey("Del", { matches: ["Delete"] }),
+        ],
+        [
+          createKey("Tab", { variant: "wide" }),
+          createKey("Q"),
+          createKey("W"),
+          createKey("E"),
+          createKey("R"),
+          createKey("T"),
+          createKey("Y"),
+          createKey("U"),
+          createKey("I"),
+          createKey("O"),
+          createKey("P"),
+          createKey("["),
+          createKey("]"),
+          createKey("\\"),
+          createKey("PgUp", { matches: ["PageUp"] }),
+        ],
+        [
+          createKey("Caps Lock", { variant: "extraWide", matches: ["CapsLock"] }),
+          createKey("A"),
+          createKey("S"),
+          createKey("D"),
+          createKey("F"),
+          createKey("G"),
+          createKey("H"),
+          createKey("J"),
+          createKey("K"),
+          createKey("L"),
+          createKey(";"),
+          createKey("'"),
+          createKey("Enter", { variant: "extraWide", matches: ["Enter", "Return"] }),
+          createKey("PgDn", { matches: ["PageDown"] }),
+        ],
+        [
+          createKey("Shift", { variant: "extraWide", matches: ["Shift"] }),
+          createKey("Z"),
+          createKey("X"),
+          createKey("C"),
+          createKey("V"),
+          createKey("B"),
+          createKey("N"),
+          createKey("M"),
+          createKey(","),
+          createKey("."),
+          createKey("/"),
+          createKey("Shift", { variant: "wide", matches: ["Shift"] }),
+          createKey("↑", { matches: ["ArrowUp"] }),
+          createKey("End"),
+        ],
+        [
+          createKey("Ctrl", { variant: "wide", category: "modifier", matches: ["Control"] }),
+          createKey("Win", {
+            variant: "wide",
+            category: "modifier",
+            osLabel: { win: "Win", mac: "Cmd" },
+            macSymbol: "⌘",
+            matches: ["Meta", "OS", "Command"],
+          }),
+          createKey("Alt", {
+            variant: "wide",
+            category: "modifier",
+            osLabel: { win: "Alt", mac: "Option" },
+            macSymbol: "⌥",
+            matches: ["Option"],
+          }),
+          createKey("Space", { variant: "space", matches: ["Space"] }),
+          createKey("Alt", {
+            variant: "wide",
+            category: "modifier",
+            osLabel: { win: "Alt", mac: "Option" },
+            macSymbol: "⌥",
+            matches: ["Option"],
+          }),
+          createKey("Win", {
+            variant: "wide",
+            category: "modifier",
+            osLabel: { win: "Win", mac: "Cmd" },
+            macSymbol: "⌘",
+            matches: ["Meta", "OS", "Command"],
+          }),
+          createKey("Fn", { variant: "wide", category: "function" }),
+          createKey("Ctrl", { variant: "wide", category: "modifier", matches: ["Control"] }),
+        ],
+      ],
+    },
+  },
+  {
+    id: "sixty",
+    title: "60% 布局 (61 键)",
+    main: {
+      rows: [
+        [
+          createKey("~"),
+          createKey("1"),
+          createKey("2"),
+          createKey("3"),
+          createKey("4"),
+          createKey("5"),
+          createKey("6"),
+          createKey("7"),
+          createKey("8"),
+          createKey("9"),
+          createKey("0"),
+          createKey("-"),
+          createKey("="),
+          createKey("Backspace", { variant: "wide", matches: ["Backspace"] }),
+        ],
+        [
+          createKey("Tab", { variant: "wide" }),
+          createKey("Q"),
+          createKey("W"),
+          createKey("E"),
+          createKey("R"),
+          createKey("T"),
+          createKey("Y"),
+          createKey("U"),
+          createKey("I"),
+          createKey("O"),
+          createKey("P"),
+          createKey("["),
+          createKey("]"),
+          createKey("\\"),
+        ],
+        [
+          createKey("Caps Lock", { variant: "extraWide", matches: ["CapsLock"] }),
+          createKey("A"),
+          createKey("S"),
+          createKey("D"),
+          createKey("F"),
+          createKey("G"),
+          createKey("H"),
+          createKey("J"),
+          createKey("K"),
+          createKey("L"),
+          createKey(";"),
+          createKey("'"),
+          createKey("Enter", { variant: "extraWide", matches: ["Enter", "Return"] }),
+        ],
+        [
+          createKey("Shift", { variant: "extraWide", matches: ["Shift"] }),
+          createKey("Z"),
+          createKey("X"),
+          createKey("C"),
+          createKey("V"),
+          createKey("B"),
+          createKey("N"),
+          createKey("M"),
+          createKey(","),
+          createKey("."),
+          createKey("/"),
+          createKey("Shift", { variant: "extraWide", matches: ["Shift"] }),
+        ],
+        [
+          createKey("Ctrl", { variant: "wide", category: "modifier", matches: ["Control"] }),
+          createKey("Win", {
+            variant: "wide",
+            category: "modifier",
+            osLabel: { win: "Win", mac: "Cmd" },
+            macSymbol: "⌘",
+            matches: ["Meta", "OS", "Command"],
+          }),
+          createKey("Alt", {
+            variant: "wide",
+            category: "modifier",
+            osLabel: { win: "Alt", mac: "Option" },
+            macSymbol: "⌥",
+            matches: ["Option"],
+          }),
+          createKey("Space", { variant: "space", matches: ["Space"] }),
+          createKey("Alt", {
+            variant: "wide",
+            category: "modifier",
+            osLabel: { win: "Alt", mac: "Option" },
+            macSymbol: "⌥",
+            matches: ["Option"],
+          }),
+          createKey("Win", {
+            variant: "wide",
+            category: "modifier",
+            osLabel: { win: "Win", mac: "Cmd" },
+            macSymbol: "⌘",
+            matches: ["Meta", "OS", "Command"],
+          }),
+          createKey("Fn", { variant: "wide", category: "function" }),
+          createKey("Ctrl", { variant: "wide", category: "modifier", matches: ["Control"] }),
+        ],
+      ],
+    },
+  },
+];
+
+const normalizeKeyEvent = (key: string): string | null => {
+  if (!key) return null;
+  if (key === " ") {
+    return "SPACE";
+  }
+  if (key === "Dead") {
+    return null;
+  }
+
+  return key.replace(/\s+/g, "").toUpperCase();
+};
+
+const colSpanClasses: Record<number, string> = {
+  2: "col-span-2",
+  3: "col-span-3",
+};
+
+const rowSpanClasses: Record<number, string> = {
+  2: "row-span-2",
+};
+
+type KeyCapProps = {
+  spec: KeyDefinition;
+  isMac: boolean;
+  pressedKeys: Set<string>;
+  isGrid?: boolean;
+};
+
+const KeyCap = ({ spec, isMac, pressedKeys, isGrid }: KeyCapProps) => {
+  const displayLabel = spec.osLabel
+    ? isMac
+      ? spec.osLabel.mac
+      : spec.osLabel.win
+    : spec.label;
+
+  const highlighted = spec.matches.some((match) => pressedKeys.has(match));
+
+  const classes = clsx(
+    "flex h-12 min-w-[36px] select-none items-center justify-center rounded-lg border px-2 text-[11px] font-medium text-slate-100 shadow-sm transition-transform duration-150",
+    categoryClasses[spec.category ?? "neutral"],
+    spec.variant ? variantClasses[spec.variant] : null,
+    spec.rowSpan ? "h-full" : null,
+    isGrid ? "w-full" : null,
+    spec.colSpan ? colSpanClasses[spec.colSpan] : null,
+    spec.rowSpan ? rowSpanClasses[spec.rowSpan] : null,
+    highlighted
+      ? "scale-[1.05] border-emerald-400 bg-emerald-500/80 text-white shadow-[0_0_14px_rgba(16,185,129,0.45)]"
+      : null
+  );
+
+  return (
+    <div className={classes} aria-pressed={highlighted} role="button">
+      {isMac && spec.osLabel ? (
+        <span className="flex items-center gap-1 text-xs">
+          {spec.macSymbol && <span className="text-sm leading-none">{spec.macSymbol}</span>}
+          <span>{spec.osLabel.mac}</span>
+        </span>
+      ) : (
+        <span className="text-xs">{displayLabel}</span>
+      )}
+    </div>
+  );
+};
+
+type RowRendererProps = {
+  row: KeySpec[];
+  isMac: boolean;
+  pressedKeys: Set<string>;
+};
+
+const ArrowCluster = ({ isMac, pressedKeys }: { isMac: boolean; pressedKeys: Set<string> }) => {
+  return (
+    <div className="flex flex-col items-center gap-1">
+      <div className="flex justify-center">
+        <KeyCap spec={arrowKeys.up} isMac={isMac} pressedKeys={pressedKeys} />
+      </div>
+      <div className="flex items-center justify-center gap-1">
+        <KeyCap spec={arrowKeys.left} isMac={isMac} pressedKeys={pressedKeys} />
+        <KeyCap spec={arrowKeys.down} isMac={isMac} pressedKeys={pressedKeys} />
+        <KeyCap spec={arrowKeys.right} isMac={isMac} pressedKeys={pressedKeys} />
+      </div>
+    </div>
+  );
+};
+
+const RowRenderer = ({ row, isMac, pressedKeys }: RowRendererProps) => {
+  return (
+    <div className="flex flex-wrap items-center justify-center gap-1">
+      {row.map((item, index) => {
+        if (item.kind === "gap") {
+          return <div key={`gap-${index}`} className={gapClasses[item.size ?? "md"]} aria-hidden />;
+        }
+
+        if (item.kind === "arrows") {
+          return <ArrowCluster key={`arrows-${index}`} isMac={isMac} pressedKeys={pressedKeys} />;
+        }
+
+        return <KeyCap key={`${item.label}-${index}`} spec={item} isMac={isMac} pressedKeys={pressedKeys} />;
+      })}
+    </div>
+  );
+};
+
+type KeyboardSectionProps = {
+  section: LayoutSection;
+  isMac: boolean;
+  pressedKeys: Set<string>;
+};
+
+const KeyboardSection = ({ section, isMac, pressedKeys }: KeyboardSectionProps) => {
+  return (
+    <div className="space-y-2">
+      {section.rows.map((row, index) => (
+        <RowRenderer key={index} row={row} isMac={isMac} pressedKeys={pressedKeys} />
+      ))}
+    </div>
+  );
+};
+
+type NumpadProps = {
+  section: NumpadSection;
+  isMac: boolean;
+  pressedKeys: Set<string>;
+};
+
+const Numpad = ({ section, isMac, pressedKeys }: NumpadProps) => {
+  return (
+    <div className="grid grid-cols-4 gap-1">
+      {section.grid.map((keyDef, index) => (
+        <KeyCap key={`${keyDef.label}-${index}`} spec={keyDef} isMac={isMac} pressedKeys={pressedKeys} isGrid />
+      ))}
+    </div>
+  );
+};
+const navItems = layouts.map((layout) => ({ id: layout.id, title: layout.title }));
+
+export default function KeyboardLayoutsPage() {
+  const [isMac, setIsMac] = useState(false);
+  const [sidebarOpen, setSidebarOpen] = useState(false);
+  const [pressedKeys, setPressedKeys] = useState<Set<string>>(new Set());
+
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      const normalized = normalizeKeyEvent(event.key);
+      if (!normalized) return;
+
+      setPressedKeys((prev) => {
+        if (prev.has(normalized)) {
+          return prev;
+        }
+        const next = new Set(prev);
+        next.add(normalized);
+        return next;
+      });
+    };
+
+    const handleKeyUp = (event: KeyboardEvent) => {
+      const normalized = normalizeKeyEvent(event.key);
+      if (!normalized) return;
+
+      setPressedKeys((prev) => {
+        if (!prev.has(normalized)) {
+          return prev;
+        }
+        const next = new Set(prev);
+        next.delete(normalized);
+        return next;
+      });
+    };
+
+    const clearPressed = () => setPressedKeys(new Set());
+
+    window.addEventListener("keydown", handleKeyDown);
+    window.addEventListener("keyup", handleKeyUp);
+    window.addEventListener("blur", clearPressed);
+
+    return () => {
+      window.removeEventListener("keydown", handleKeyDown);
+      window.removeEventListener("keyup", handleKeyUp);
+      window.removeEventListener("blur", clearPressed);
+    };
+  }, []);
+
+  const containerShift = sidebarOpen ? "lg:pl-52" : "lg:pl-16";
+
+  return (
+    <div className="relative pb-16">
+      <button
+        type="button"
+        onClick={() => setIsMac((prev) => !prev)}
+        className="fixed right-6 top-6 z-40 rounded-full border border-slate-700 bg-slate-900/80 px-4 py-2 text-xs font-medium text-slate-200 shadow-lg transition-colors hover:border-brand-light hover:text-white"
+      >
+        {isMac ? "切换到 Windows" : "切换到 Mac"}
+      </button>
+
+      <nav
+        className={clsx(
+          "fixed left-0 top-1/2 z-30 -translate-y-1/2 rounded-r-xl border border-slate-800 bg-slate-900/80 p-4 shadow-xl shadow-black/30 transition-transform duration-300",
+          sidebarOpen ? "translate-x-0" : "-translate-x-[70%]"
+        )}
+        aria-label="键盘布局导航"
+      >
+        <button
+          type="button"
+          onClick={() => setSidebarOpen((prev) => !prev)}
+          className="absolute -right-10 top-1/2 flex h-10 w-10 -translate-y-1/2 items-center justify-center rounded-r-xl border border-slate-800 bg-slate-900 text-slate-200 shadow-md transition-colors hover:border-brand-light"
+          aria-label={sidebarOpen ? "收起导航" : "展开导航"}
+        >
+          <span className={clsx("text-lg transition-transform", sidebarOpen ? "rotate-180" : "")}>{"❯"}</span>
+        </button>
+        <ul className="space-y-2 text-sm text-slate-200">
+          {navItems.map((item) => (
+            <li key={item.id}>
+              <a
+                href={`#${item.id}`}
+                className="block rounded-lg px-3 py-2 transition-colors hover:bg-slate-800/70 hover:text-white"
+              >
+                {item.title}
+              </a>
+            </li>
+          ))}
+        </ul>
+      </nav>
+
+      <div className={clsx("mx-auto w-full max-w-[1280px] space-y-10 px-4 pt-8 transition-all duration-300", containerShift)}>
+        <header className="space-y-3">
+          <span className="badge">键盘</span>
+          <h1 className="text-3xl font-bold text-white">常见机械键盘布局一览</h1>
+          <p className="text-sm text-slate-300">
+            通过直观的键帽示意对比 100% 到 60% 多种布局形态，可实时切换 Windows / Mac 键位显示，并支持键盘输入高亮对应按键，帮助理解不同配列的功能分区。
+          </p>
+        </header>
+
+        <div className="space-y-10">
+          {layouts.map((layout) => (
+            <section
+              key={layout.id}
+              id={layout.id}
+              className="rounded-2xl border border-slate-800 bg-slate-900/60 p-6 shadow-xl shadow-black/20 backdrop-blur"
+            >
+              <h2 className="text-xl font-semibold text-white">{layout.title}</h2>
+              <div className={clsx("mt-6 flex flex-col gap-8 lg:flex-row lg:items-start", layout.className)}>
+                <div className="flex-1">
+                  <KeyboardSection section={layout.main} isMac={isMac} pressedKeys={pressedKeys} />
+                </div>
+                {layout.control && (
+                  <div className="flex-shrink-0 lg:w-44">
+                    <KeyboardSection section={layout.control} isMac={isMac} pressedKeys={pressedKeys} />
+                  </div>
+                )}
+                {layout.numpad && (
+                  <div className="flex-shrink-0 lg:w-48">
+                    <Numpad section={layout.numpad} isMac={isMac} pressedKeys={pressedKeys} />
+                  </div>
+                )}
+              </div>
+            </section>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -6,7 +6,8 @@ const navigation = [
   { href: '/', label: '首页' },
   { href: '/phonetics', label: '英语音标' },
   { href: '/greek', label: '希腊字母' },
-  { href: '/encoding', label: '编码查询' }
+  { href: '/encoding', label: '编码查询' },
+  { href: '/keyboards', label: '键盘布局' }
 ];
 
 export const metadata: Metadata = {

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -18,6 +18,12 @@ const features = [
     description: '输入字符即可查看 Unicode 码点、UTF-8 字节和 HTML 转义序列。',
     href: '/encoding',
     badge: '编码'
+  },
+  {
+    title: '机械键盘布局',
+    description: '比较 100% 至 60% 各类配列，支持切换 Windows / Mac 键位并实时高亮按键输入。',
+    href: '/keyboards',
+    badge: '输入'
   }
 ];
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,193 +1,160 @@
-lockfileVersion: 5.4
+lockfileVersion: '9.0'
 
-specifiers:
-  '@radix-ui/react-slot': ^1.2.3
-  '@types/node': ^24.6.2
-  '@types/react': ^19.2.0
-  '@types/react-dom': ^19.2.0
-  autoprefixer: ^10.4.21
-  class-variance-authority: ^0.7.1
-  clsx: ^2.1.1
-  lucide-react: ^0.544.0
-  next: 14.2.33
-  postcss: ^8.5.6
-  react: 18.2.0
-  react-dom: 18.2.0
-  tailwind-merge: ^3.3.1
-  tailwindcss: ^3.4.14
-  tailwindcss-animate: ^1.0.7
-  typescript: ^5.9.3
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
 
-dependencies:
-  '@radix-ui/react-slot': 1.2.3_jzum5zd7eh7krambdfd4lxwsl4
-  class-variance-authority: 0.7.1
-  clsx: 2.1.1
-  lucide-react: 0.544.0_react@18.2.0
-  next: 14.2.33_biqbaboplfbrettd7655fr4n2y
-  react: 18.2.0
-  react-dom: 18.2.0_react@18.2.0
-  tailwind-merge: 3.3.1
-  tailwindcss-animate: 1.0.7_tailwindcss@3.4.18
+importers:
 
-devDependencies:
-  '@types/node': 24.6.2
-  '@types/react': 19.2.0
-  '@types/react-dom': 19.2.0_@types+react@19.2.0
-  autoprefixer: 10.4.21_postcss@8.5.6
-  postcss: 8.5.6
-  tailwindcss: 3.4.18
-  typescript: 5.9.3
+  .:
+    dependencies:
+      '@radix-ui/react-slot':
+        specifier: ^1.2.3
+        version: 1.2.3(@types/react@19.2.0)(react@18.2.0)
+      class-variance-authority:
+        specifier: ^0.7.1
+        version: 0.7.1
+      clsx:
+        specifier: ^2.1.1
+        version: 2.1.1
+      lucide-react:
+        specifier: ^0.544.0
+        version: 0.544.0(react@18.2.0)
+      next:
+        specifier: 14.2.33
+        version: 14.2.33(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      react:
+        specifier: 18.2.0
+        version: 18.2.0
+      react-dom:
+        specifier: 18.2.0
+        version: 18.2.0(react@18.2.0)
+      tailwind-merge:
+        specifier: ^3.3.1
+        version: 3.3.1
+      tailwindcss-animate:
+        specifier: ^1.0.7
+        version: 1.0.7(tailwindcss@3.4.18)
+    devDependencies:
+      '@types/node':
+        specifier: ^24.6.2
+        version: 24.6.2
+      '@types/react':
+        specifier: ^19.2.0
+        version: 19.2.0
+      '@types/react-dom':
+        specifier: ^19.2.0
+        version: 19.2.0(@types/react@19.2.0)
+      autoprefixer:
+        specifier: ^10.4.21
+        version: 10.4.21(postcss@8.5.6)
+      postcss:
+        specifier: ^8.5.6
+        version: 8.5.6
+      tailwindcss:
+        specifier: ^3.4.14
+        version: 3.4.18
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
 
 packages:
 
-  /@alloc/quick-lru/5.2.0:
+  '@alloc/quick-lru@5.2.0':
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
     engines: {node: '>=10'}
 
-  /@isaacs/cliui/8.0.2:
+  '@isaacs/cliui@8.0.2':
     resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
     engines: {node: '>=12'}
-    dependencies:
-      string-width: 5.1.2
-      string-width-cjs: /string-width/4.2.3
-      strip-ansi: 7.1.2
-      strip-ansi-cjs: /strip-ansi/6.0.1
-      wrap-ansi: 8.1.0
-      wrap-ansi-cjs: /wrap-ansi/7.0.0
 
-  /@jridgewell/gen-mapping/0.3.13:
+  '@jridgewell/gen-mapping@0.3.13':
     resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
-    dependencies:
-      '@jridgewell/sourcemap-codec': 1.5.5
-      '@jridgewell/trace-mapping': 0.3.31
 
-  /@jridgewell/resolve-uri/3.1.2:
+  '@jridgewell/resolve-uri@3.1.2':
     resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
     engines: {node: '>=6.0.0'}
 
-  /@jridgewell/sourcemap-codec/1.5.5:
+  '@jridgewell/sourcemap-codec@1.5.5':
     resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
 
-  /@jridgewell/trace-mapping/0.3.31:
+  '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
-    dependencies:
-      '@jridgewell/resolve-uri': 3.1.2
-      '@jridgewell/sourcemap-codec': 1.5.5
 
-  /@next/env/14.2.33:
+  '@next/env@14.2.33':
     resolution: {integrity: sha512-CgVHNZ1fRIlxkLhIX22flAZI/HmpDaZ8vwyJ/B0SDPTBuLZ1PJ+DWMjCHhqnExfmSQzA/PbZi8OAc7PAq2w9IA==}
-    dev: false
 
-  /@next/swc-darwin-arm64/14.2.33:
+  '@next/swc-darwin-arm64@14.2.33':
     resolution: {integrity: sha512-HqYnb6pxlsshoSTubdXKu15g3iivcbsMXg4bYpjL2iS/V6aQot+iyF4BUc2qA/J/n55YtvE4PHMKWBKGCF/+wA==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [darwin]
-    requiresBuild: true
-    dev: false
-    optional: true
 
-  /@next/swc-darwin-x64/14.2.33:
+  '@next/swc-darwin-x64@14.2.33':
     resolution: {integrity: sha512-8HGBeAE5rX3jzKvF593XTTFg3gxeU4f+UWnswa6JPhzaR6+zblO5+fjltJWIZc4aUalqTclvN2QtTC37LxvZAA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [darwin]
-    requiresBuild: true
-    dev: false
-    optional: true
 
-  /@next/swc-linux-arm64-gnu/14.2.33:
+  '@next/swc-linux-arm64-gnu@14.2.33':
     resolution: {integrity: sha512-JXMBka6lNNmqbkvcTtaX8Gu5by9547bukHQvPoLe9VRBx1gHwzf5tdt4AaezW85HAB3pikcvyqBToRTDA4DeLw==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
-    requiresBuild: true
-    dev: false
-    optional: true
 
-  /@next/swc-linux-arm64-musl/14.2.33:
+  '@next/swc-linux-arm64-musl@14.2.33':
     resolution: {integrity: sha512-Bm+QulsAItD/x6Ih8wGIMfRJy4G73tu1HJsrccPW6AfqdZd0Sfm5Imhgkgq2+kly065rYMnCOxTBvmvFY1BKfg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
-    requiresBuild: true
-    dev: false
-    optional: true
 
-  /@next/swc-linux-x64-gnu/14.2.33:
+  '@next/swc-linux-x64-gnu@14.2.33':
     resolution: {integrity: sha512-FnFn+ZBgsVMbGDsTqo8zsnRzydvsGV8vfiWwUo1LD8FTmPTdV+otGSWKc4LJec0oSexFnCYVO4hX8P8qQKaSlg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
-    requiresBuild: true
-    dev: false
-    optional: true
 
-  /@next/swc-linux-x64-musl/14.2.33:
+  '@next/swc-linux-x64-musl@14.2.33':
     resolution: {integrity: sha512-345tsIWMzoXaQndUTDv1qypDRiebFxGYx9pYkhwY4hBRaOLt8UGfiWKr9FSSHs25dFIf8ZqIFaPdy5MljdoawA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
-    requiresBuild: true
-    dev: false
-    optional: true
 
-  /@next/swc-win32-arm64-msvc/14.2.33:
+  '@next/swc-win32-arm64-msvc@14.2.33':
     resolution: {integrity: sha512-nscpt0G6UCTkrT2ppnJnFsYbPDQwmum4GNXYTeoTIdsmMydSKFz9Iny2jpaRupTb+Wl298+Rh82WKzt9LCcqSQ==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [win32]
-    requiresBuild: true
-    dev: false
-    optional: true
 
-  /@next/swc-win32-ia32-msvc/14.2.33:
+  '@next/swc-win32-ia32-msvc@14.2.33':
     resolution: {integrity: sha512-pc9LpGNKhJ0dXQhZ5QMmYxtARwwmWLpeocFmVG5Z0DzWq5Uf0izcI8tLc+qOpqxO1PWqZ5A7J1blrUIKrIFc7Q==}
     engines: {node: '>= 10'}
     cpu: [ia32]
     os: [win32]
-    requiresBuild: true
-    dev: false
-    optional: true
 
-  /@next/swc-win32-x64-msvc/14.2.33:
+  '@next/swc-win32-x64-msvc@14.2.33':
     resolution: {integrity: sha512-nOjfZMy8B94MdisuzZo9/57xuFVLHJaDj5e/xrduJp9CV2/HrfxTRH2fbyLe+K9QT41WBLUd4iXX3R7jBp0EUg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [win32]
-    requiresBuild: true
-    dev: false
-    optional: true
 
-  /@nodelib/fs.scandir/2.1.5:
+  '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
     engines: {node: '>= 8'}
-    dependencies:
-      '@nodelib/fs.stat': 2.0.5
-      run-parallel: 1.2.0
 
-  /@nodelib/fs.stat/2.0.5:
+  '@nodelib/fs.stat@2.0.5':
     resolution: {integrity: sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==}
     engines: {node: '>= 8'}
 
-  /@nodelib/fs.walk/1.2.8:
+  '@nodelib/fs.walk@1.2.8':
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
-    dependencies:
-      '@nodelib/fs.scandir': 2.1.5
-      fastq: 1.19.1
 
-  /@pkgjs/parseargs/0.11.0:
+  '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
-    requiresBuild: true
-    optional: true
 
-  /@radix-ui/react-compose-refs/1.1.2_jzum5zd7eh7krambdfd4lxwsl4:
+  '@radix-ui/react-compose-refs@1.1.2':
     resolution: {integrity: sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg==}
     peerDependencies:
       '@types/react': '*'
@@ -195,12 +162,8 @@ packages:
     peerDependenciesMeta:
       '@types/react':
         optional: true
-    dependencies:
-      '@types/react': 19.2.0
-      react: 18.2.0
-    dev: false
 
-  /@radix-ui/react-slot/1.2.3_jzum5zd7eh7krambdfd4lxwsl4:
+  '@radix-ui/react-slot@1.2.3':
     resolution: {integrity: sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==}
     peerDependencies:
       '@types/react': '*'
@@ -208,402 +171,276 @@ packages:
     peerDependenciesMeta:
       '@types/react':
         optional: true
-    dependencies:
-      '@radix-ui/react-compose-refs': 1.1.2_jzum5zd7eh7krambdfd4lxwsl4
-      '@types/react': 19.2.0
-      react: 18.2.0
-    dev: false
 
-  /@swc/counter/0.1.3:
+  '@swc/counter@0.1.3':
     resolution: {integrity: sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==}
-    dev: false
 
-  /@swc/helpers/0.5.5:
+  '@swc/helpers@0.5.5':
     resolution: {integrity: sha512-KGYxvIOXcceOAbEk4bi/dVLEK9z8sZ0uBB3Il5b1rhfClSpcX0yfRO0KmTkqR2cnQDymwLB+25ZyMzICg/cm/A==}
-    dependencies:
-      '@swc/counter': 0.1.3
-      tslib: 2.8.1
-    dev: false
 
-  /@types/node/24.6.2:
+  '@types/node@24.6.2':
     resolution: {integrity: sha512-d2L25Y4j+W3ZlNAeMKcy7yDsK425ibcAOO2t7aPTz6gNMH0z2GThtwENCDc0d/Pw9wgyRqE5Px1wkV7naz8ang==}
-    dependencies:
-      undici-types: 7.13.0
-    dev: true
 
-  /@types/react-dom/19.2.0_@types+react@19.2.0:
+  '@types/react-dom@19.2.0':
     resolution: {integrity: sha512-brtBs0MnE9SMx7px208g39lRmC5uHZs96caOJfTjFcYSLHNamvaSMfJNagChVNkup2SdtOxKX1FDBkRSJe1ZAg==}
     peerDependencies:
       '@types/react': ^19.2.0
-    dependencies:
-      '@types/react': 19.2.0
-    dev: true
 
-  /@types/react/19.2.0:
+  '@types/react@19.2.0':
     resolution: {integrity: sha512-1LOH8xovvsKsCBq1wnT4ntDUdCJKmnEakhsuoUSy6ExlHCkGP2hqnatagYTgFk6oeL0VU31u7SNjunPN+GchtA==}
-    dependencies:
-      csstype: 3.1.3
 
-  /ansi-regex/5.0.1:
+  ansi-regex@5.0.1:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
     engines: {node: '>=8'}
 
-  /ansi-regex/6.2.2:
+  ansi-regex@6.2.2:
     resolution: {integrity: sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==}
     engines: {node: '>=12'}
 
-  /ansi-styles/4.3.0:
+  ansi-styles@4.3.0:
     resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
     engines: {node: '>=8'}
-    dependencies:
-      color-convert: 2.0.1
 
-  /ansi-styles/6.2.3:
+  ansi-styles@6.2.3:
     resolution: {integrity: sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==}
     engines: {node: '>=12'}
 
-  /any-promise/1.3.0:
+  any-promise@1.3.0:
     resolution: {integrity: sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==}
 
-  /anymatch/3.1.3:
+  anymatch@3.1.3:
     resolution: {integrity: sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==}
     engines: {node: '>= 8'}
-    dependencies:
-      normalize-path: 3.0.0
-      picomatch: 2.3.1
 
-  /arg/5.0.2:
+  arg@5.0.2:
     resolution: {integrity: sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==}
 
-  /autoprefixer/10.4.21_postcss@8.5.6:
+  autoprefixer@10.4.21:
     resolution: {integrity: sha512-O+A6LWV5LDHSJD3LjHYoNi4VLsj/Whi7k6zG12xTYaU4cQ8oxQGckXNX8cRHK5yOZ/ppVHe0ZBXGzSV9jXdVbQ==}
     engines: {node: ^10 || ^12 || >=14}
     hasBin: true
     peerDependencies:
       postcss: ^8.1.0
-    dependencies:
-      browserslist: 4.26.3
-      caniuse-lite: 1.0.30001747
-      fraction.js: 4.3.7
-      normalize-range: 0.1.2
-      picocolors: 1.1.1
-      postcss: 8.5.6
-      postcss-value-parser: 4.2.0
-    dev: true
 
-  /balanced-match/1.0.2:
+  balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
-  /baseline-browser-mapping/2.8.12:
+  baseline-browser-mapping@2.8.12:
     resolution: {integrity: sha512-vAPMQdnyKCBtkmQA6FMCBvU9qFIppS3nzyXnEM+Lo2IAhG4Mpjv9cCxMudhgV3YdNNJv6TNqXy97dfRVL2LmaQ==}
     hasBin: true
-    dev: true
 
-  /binary-extensions/2.3.0:
+  binary-extensions@2.3.0:
     resolution: {integrity: sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==}
     engines: {node: '>=8'}
 
-  /brace-expansion/2.0.2:
+  brace-expansion@2.0.2:
     resolution: {integrity: sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==}
-    dependencies:
-      balanced-match: 1.0.2
 
-  /braces/3.0.3:
+  braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
     engines: {node: '>=8'}
-    dependencies:
-      fill-range: 7.1.1
 
-  /browserslist/4.26.3:
+  browserslist@4.26.3:
     resolution: {integrity: sha512-lAUU+02RFBuCKQPj/P6NgjlbCnLBMp4UtgTx7vNHd3XSIJF87s9a5rA3aH2yw3GS9DqZAUbOtZdCCiZeVRqt0w==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
-    dependencies:
-      baseline-browser-mapping: 2.8.12
-      caniuse-lite: 1.0.30001747
-      electron-to-chromium: 1.5.230
-      node-releases: 2.0.23
-      update-browserslist-db: 1.1.3_browserslist@4.26.3
-    dev: true
 
-  /busboy/1.6.0:
+  busboy@1.6.0:
     resolution: {integrity: sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==}
     engines: {node: '>=10.16.0'}
-    dependencies:
-      streamsearch: 1.1.0
-    dev: false
 
-  /camelcase-css/2.0.1:
+  camelcase-css@2.0.1:
     resolution: {integrity: sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==}
     engines: {node: '>= 6'}
 
-  /caniuse-lite/1.0.30001747:
+  caniuse-lite@1.0.30001747:
     resolution: {integrity: sha512-mzFa2DGIhuc5490Nd/G31xN1pnBnYMadtkyTjefPI7wzypqgCEpeWu9bJr0OnDsyKrW75zA9ZAt7pbQFmwLsQg==}
 
-  /chokidar/3.6.0:
+  chokidar@3.6.0:
     resolution: {integrity: sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==}
     engines: {node: '>= 8.10.0'}
-    dependencies:
-      anymatch: 3.1.3
-      braces: 3.0.3
-      glob-parent: 5.1.2
-      is-binary-path: 2.1.0
-      is-glob: 4.0.3
-      normalize-path: 3.0.0
-      readdirp: 3.6.0
-    optionalDependencies:
-      fsevents: 2.3.3
 
-  /class-variance-authority/0.7.1:
+  class-variance-authority@0.7.1:
     resolution: {integrity: sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==}
-    dependencies:
-      clsx: 2.1.1
-    dev: false
 
-  /client-only/0.0.1:
+  client-only@0.0.1:
     resolution: {integrity: sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==}
-    dev: false
 
-  /clsx/2.1.1:
+  clsx@2.1.1:
     resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
     engines: {node: '>=6'}
-    dev: false
 
-  /color-convert/2.0.1:
+  color-convert@2.0.1:
     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
     engines: {node: '>=7.0.0'}
-    dependencies:
-      color-name: 1.1.4
 
-  /color-name/1.1.4:
+  color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
 
-  /commander/4.1.1:
+  commander@4.1.1:
     resolution: {integrity: sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==}
     engines: {node: '>= 6'}
 
-  /cross-spawn/7.0.6:
+  cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
-    dependencies:
-      path-key: 3.1.1
-      shebang-command: 2.0.0
-      which: 2.0.2
 
-  /cssesc/3.0.0:
+  cssesc@3.0.0:
     resolution: {integrity: sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==}
     engines: {node: '>=4'}
     hasBin: true
 
-  /csstype/3.1.3:
+  csstype@3.1.3:
     resolution: {integrity: sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==}
 
-  /didyoumean/1.2.2:
+  didyoumean@1.2.2:
     resolution: {integrity: sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==}
 
-  /dlv/1.1.3:
+  dlv@1.1.3:
     resolution: {integrity: sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==}
 
-  /eastasianwidth/0.2.0:
+  eastasianwidth@0.2.0:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
 
-  /electron-to-chromium/1.5.230:
+  electron-to-chromium@1.5.230:
     resolution: {integrity: sha512-A6A6Fd3+gMdaed9wX83CvHYJb4UuapPD5X5SLq72VZJzxHSY0/LUweGXRWmQlh2ln7KV7iw7jnwXK7dlPoOnHQ==}
-    dev: true
 
-  /emoji-regex/8.0.0:
+  emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
 
-  /emoji-regex/9.2.2:
+  emoji-regex@9.2.2:
     resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
 
-  /escalade/3.2.0:
+  escalade@3.2.0:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
     engines: {node: '>=6'}
-    dev: true
 
-  /fast-glob/3.3.3:
+  fast-glob@3.3.3:
     resolution: {integrity: sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==}
     engines: {node: '>=8.6.0'}
-    dependencies:
-      '@nodelib/fs.stat': 2.0.5
-      '@nodelib/fs.walk': 1.2.8
-      glob-parent: 5.1.2
-      merge2: 1.4.1
-      micromatch: 4.0.8
 
-  /fastq/1.19.1:
+  fastq@1.19.1:
     resolution: {integrity: sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==}
-    dependencies:
-      reusify: 1.1.0
 
-  /fill-range/7.1.1:
+  fill-range@7.1.1:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
     engines: {node: '>=8'}
-    dependencies:
-      to-regex-range: 5.0.1
 
-  /foreground-child/3.3.1:
+  foreground-child@3.3.1:
     resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
     engines: {node: '>=14'}
-    dependencies:
-      cross-spawn: 7.0.6
-      signal-exit: 4.1.0
 
-  /fraction.js/4.3.7:
+  fraction.js@4.3.7:
     resolution: {integrity: sha512-ZsDfxO51wGAXREY55a7la9LScWpwv9RxIrYABrlvOFBlH/ShPnrtsXeuUIfXKKOVicNxQ+o8JTbJvjS4M89yew==}
-    dev: true
 
-  /fsevents/2.3.3:
+  fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
-    requiresBuild: true
-    optional: true
 
-  /function-bind/1.1.2:
+  function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
 
-  /glob-parent/5.1.2:
+  glob-parent@5.1.2:
     resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
     engines: {node: '>= 6'}
-    dependencies:
-      is-glob: 4.0.3
 
-  /glob-parent/6.0.2:
+  glob-parent@6.0.2:
     resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
     engines: {node: '>=10.13.0'}
-    dependencies:
-      is-glob: 4.0.3
 
-  /glob/10.4.5:
+  glob@10.4.5:
     resolution: {integrity: sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==}
     hasBin: true
-    dependencies:
-      foreground-child: 3.3.1
-      jackspeak: 3.4.3
-      minimatch: 9.0.5
-      minipass: 7.1.2
-      package-json-from-dist: 1.0.1
-      path-scurry: 1.11.1
 
-  /graceful-fs/4.2.11:
+  graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
-    dev: false
 
-  /hasown/2.0.2:
+  hasown@2.0.2:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
     engines: {node: '>= 0.4'}
-    dependencies:
-      function-bind: 1.1.2
 
-  /is-binary-path/2.1.0:
+  is-binary-path@2.1.0:
     resolution: {integrity: sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==}
     engines: {node: '>=8'}
-    dependencies:
-      binary-extensions: 2.3.0
 
-  /is-core-module/2.16.1:
+  is-core-module@2.16.1:
     resolution: {integrity: sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==}
     engines: {node: '>= 0.4'}
-    dependencies:
-      hasown: 2.0.2
 
-  /is-extglob/2.1.1:
+  is-extglob@2.1.1:
     resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
     engines: {node: '>=0.10.0'}
 
-  /is-fullwidth-code-point/3.0.0:
+  is-fullwidth-code-point@3.0.0:
     resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
     engines: {node: '>=8'}
 
-  /is-glob/4.0.3:
+  is-glob@4.0.3:
     resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
     engines: {node: '>=0.10.0'}
-    dependencies:
-      is-extglob: 2.1.1
 
-  /is-number/7.0.0:
+  is-number@7.0.0:
     resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
     engines: {node: '>=0.12.0'}
 
-  /isexe/2.0.0:
+  isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
 
-  /jackspeak/3.4.3:
+  jackspeak@3.4.3:
     resolution: {integrity: sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==}
-    dependencies:
-      '@isaacs/cliui': 8.0.2
-    optionalDependencies:
-      '@pkgjs/parseargs': 0.11.0
 
-  /jiti/1.21.7:
+  jiti@1.21.7:
     resolution: {integrity: sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==}
     hasBin: true
 
-  /js-tokens/4.0.0:
+  js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
-    dev: false
 
-  /lilconfig/3.1.3:
+  lilconfig@3.1.3:
     resolution: {integrity: sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==}
     engines: {node: '>=14'}
 
-  /lines-and-columns/1.2.4:
+  lines-and-columns@1.2.4:
     resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
 
-  /loose-envify/1.4.0:
+  loose-envify@1.4.0:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
     hasBin: true
-    dependencies:
-      js-tokens: 4.0.0
-    dev: false
 
-  /lru-cache/10.4.3:
+  lru-cache@10.4.3:
     resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
 
-  /lucide-react/0.544.0_react@18.2.0:
+  lucide-react@0.544.0:
     resolution: {integrity: sha512-t5tS44bqd825zAW45UQxpG2CvcC4urOwn2TrwSH8u+MjeE+1NnWl6QqeQ/6NdjMqdOygyiT9p3Ev0p1NJykxjw==}
     peerDependencies:
       react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
-    dependencies:
-      react: 18.2.0
-    dev: false
 
-  /merge2/1.4.1:
+  merge2@1.4.1:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
     engines: {node: '>= 8'}
 
-  /micromatch/4.0.8:
+  micromatch@4.0.8:
     resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
     engines: {node: '>=8.6'}
-    dependencies:
-      braces: 3.0.3
-      picomatch: 2.3.1
 
-  /minimatch/9.0.5:
+  minimatch@9.0.5:
     resolution: {integrity: sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==}
     engines: {node: '>=16 || 14 >=14.17'}
-    dependencies:
-      brace-expansion: 2.0.2
 
-  /minipass/7.1.2:
+  minipass@7.1.2:
     resolution: {integrity: sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==}
     engines: {node: '>=16 || 14 >=14.17'}
 
-  /mz/2.7.0:
+  mz@2.7.0:
     resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
-    dependencies:
-      any-promise: 1.3.0
-      object-assign: 4.1.1
-      thenify-all: 1.6.0
 
-  /nanoid/3.3.11:
+  nanoid@3.3.11:
     resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
-  /next/14.2.33_biqbaboplfbrettd7655fr4n2y:
+  next@14.2.33:
     resolution: {integrity: sha512-GiKHLsD00t4ACm1p00VgrI0rUFAC9cRDGReKyERlM57aeEZkOQGcZTpIbsGn0b562FTPJWmYfKwplfO9EaT6ng==}
     engines: {node: '>=18.17.0'}
     hasBin: true
@@ -620,105 +457,68 @@ packages:
         optional: true
       sass:
         optional: true
-    dependencies:
-      '@next/env': 14.2.33
-      '@swc/helpers': 0.5.5
-      busboy: 1.6.0
-      caniuse-lite: 1.0.30001747
-      graceful-fs: 4.2.11
-      postcss: 8.4.31
-      react: 18.2.0
-      react-dom: 18.2.0_react@18.2.0
-      styled-jsx: 5.1.1_react@18.2.0
-    optionalDependencies:
-      '@next/swc-darwin-arm64': 14.2.33
-      '@next/swc-darwin-x64': 14.2.33
-      '@next/swc-linux-arm64-gnu': 14.2.33
-      '@next/swc-linux-arm64-musl': 14.2.33
-      '@next/swc-linux-x64-gnu': 14.2.33
-      '@next/swc-linux-x64-musl': 14.2.33
-      '@next/swc-win32-arm64-msvc': 14.2.33
-      '@next/swc-win32-ia32-msvc': 14.2.33
-      '@next/swc-win32-x64-msvc': 14.2.33
-    transitivePeerDependencies:
-      - '@babel/core'
-      - babel-plugin-macros
-    dev: false
 
-  /node-releases/2.0.23:
+  node-releases@2.0.23:
     resolution: {integrity: sha512-cCmFDMSm26S6tQSDpBCg/NR8NENrVPhAJSf+XbxBG4rPFaaonlEoE9wHQmun+cls499TQGSb7ZyPBRlzgKfpeg==}
-    dev: true
 
-  /normalize-path/3.0.0:
+  normalize-path@3.0.0:
     resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
     engines: {node: '>=0.10.0'}
 
-  /normalize-range/0.1.2:
+  normalize-range@0.1.2:
     resolution: {integrity: sha512-bdok/XvKII3nUpklnV6P2hxtMNrCboOjAcyBuQnWEhO665FwrSNRxU+AqpsyvO6LgGYPspN+lu5CLtw4jPRKNA==}
     engines: {node: '>=0.10.0'}
-    dev: true
 
-  /object-assign/4.1.1:
+  object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
 
-  /object-hash/3.0.0:
+  object-hash@3.0.0:
     resolution: {integrity: sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==}
     engines: {node: '>= 6'}
 
-  /package-json-from-dist/1.0.1:
+  package-json-from-dist@1.0.1:
     resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
 
-  /path-key/3.1.1:
+  path-key@3.1.1:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
     engines: {node: '>=8'}
 
-  /path-parse/1.0.7:
+  path-parse@1.0.7:
     resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
 
-  /path-scurry/1.11.1:
+  path-scurry@1.11.1:
     resolution: {integrity: sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==}
     engines: {node: '>=16 || 14 >=14.18'}
-    dependencies:
-      lru-cache: 10.4.3
-      minipass: 7.1.2
 
-  /picocolors/1.1.1:
+  picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
-  /picomatch/2.3.1:
+  picomatch@2.3.1:
     resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==}
     engines: {node: '>=8.6'}
 
-  /pify/2.3.0:
+  pify@2.3.0:
     resolution: {integrity: sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==}
     engines: {node: '>=0.10.0'}
 
-  /pirates/4.0.7:
+  pirates@4.0.7:
     resolution: {integrity: sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==}
     engines: {node: '>= 6'}
 
-  /postcss-import/15.1.0_postcss@8.5.6:
+  postcss-import@15.1.0:
     resolution: {integrity: sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
       postcss: ^8.0.0
-    dependencies:
-      postcss: 8.5.6
-      postcss-value-parser: 4.2.0
-      read-cache: 1.0.0
-      resolve: 1.22.10
 
-  /postcss-js/4.1.0_postcss@8.5.6:
+  postcss-js@4.1.0:
     resolution: {integrity: sha512-oIAOTqgIo7q2EOwbhb8UalYePMvYoIeRY2YKntdpFQXNosSu3vLrniGgmH9OKs/qAkfoj5oB3le/7mINW1LCfw==}
     engines: {node: ^12 || ^14 || >= 16}
     peerDependencies:
       postcss: ^8.4.21
-    dependencies:
-      camelcase-css: 2.0.1
-      postcss: 8.5.6
 
-  /postcss-load-config/6.0.1_jiti@1.21.7+postcss@8.5.6:
+  postcss-load-config@6.0.1:
     resolution: {integrity: sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g==}
     engines: {node: '>= 18'}
     peerDependencies:
@@ -735,154 +535,99 @@ packages:
         optional: true
       yaml:
         optional: true
-    dependencies:
-      jiti: 1.21.7
-      lilconfig: 3.1.3
-      postcss: 8.5.6
 
-  /postcss-nested/6.2.0_postcss@8.5.6:
+  postcss-nested@6.2.0:
     resolution: {integrity: sha512-HQbt28KulC5AJzG+cZtj9kvKB93CFCdLvog1WFLf1D+xmMvPGlBstkpTEZfK5+AN9hfJocyBFCNiqyS48bpgzQ==}
     engines: {node: '>=12.0'}
     peerDependencies:
       postcss: ^8.2.14
-    dependencies:
-      postcss: 8.5.6
-      postcss-selector-parser: 6.1.2
 
-  /postcss-selector-parser/6.1.2:
+  postcss-selector-parser@6.1.2:
     resolution: {integrity: sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==}
     engines: {node: '>=4'}
-    dependencies:
-      cssesc: 3.0.0
-      util-deprecate: 1.0.2
 
-  /postcss-value-parser/4.2.0:
+  postcss-value-parser@4.2.0:
     resolution: {integrity: sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==}
 
-  /postcss/8.4.31:
+  postcss@8.4.31:
     resolution: {integrity: sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==}
     engines: {node: ^10 || ^12 || >=14}
-    dependencies:
-      nanoid: 3.3.11
-      picocolors: 1.1.1
-      source-map-js: 1.2.1
-    dev: false
 
-  /postcss/8.5.6:
+  postcss@8.5.6:
     resolution: {integrity: sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==}
     engines: {node: ^10 || ^12 || >=14}
-    dependencies:
-      nanoid: 3.3.11
-      picocolors: 1.1.1
-      source-map-js: 1.2.1
 
-  /queue-microtask/1.2.3:
+  queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
 
-  /react-dom/18.2.0_react@18.2.0:
+  react-dom@18.2.0:
     resolution: {integrity: sha512-6IMTriUmvsjHUjNtEDudZfuDQUoWXVxKHhlEGSk81n4YFS+r/Kl99wXiwlVXtPBtJenozv2P+hxDsw9eA7Xo6g==}
     peerDependencies:
       react: ^18.2.0
-    dependencies:
-      loose-envify: 1.4.0
-      react: 18.2.0
-      scheduler: 0.23.2
-    dev: false
 
-  /react/18.2.0:
+  react@18.2.0:
     resolution: {integrity: sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==}
     engines: {node: '>=0.10.0'}
-    dependencies:
-      loose-envify: 1.4.0
-    dev: false
 
-  /read-cache/1.0.0:
+  read-cache@1.0.0:
     resolution: {integrity: sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA==}
-    dependencies:
-      pify: 2.3.0
 
-  /readdirp/3.6.0:
+  readdirp@3.6.0:
     resolution: {integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==}
     engines: {node: '>=8.10.0'}
-    dependencies:
-      picomatch: 2.3.1
 
-  /resolve/1.22.10:
+  resolve@1.22.10:
     resolution: {integrity: sha512-NPRy+/ncIMeDlTAsuqwKIiferiawhefFJtkNSW0qZJEqMEb+qBt/77B/jGeeek+F0uOeN05CDa6HXbbIgtVX4w==}
     engines: {node: '>= 0.4'}
     hasBin: true
-    dependencies:
-      is-core-module: 2.16.1
-      path-parse: 1.0.7
-      supports-preserve-symlinks-flag: 1.0.0
 
-  /reusify/1.1.0:
+  reusify@1.1.0:
     resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
 
-  /run-parallel/1.2.0:
+  run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
-    dependencies:
-      queue-microtask: 1.2.3
 
-  /scheduler/0.23.2:
+  scheduler@0.23.2:
     resolution: {integrity: sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==}
-    dependencies:
-      loose-envify: 1.4.0
-    dev: false
 
-  /shebang-command/2.0.0:
+  shebang-command@2.0.0:
     resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
     engines: {node: '>=8'}
-    dependencies:
-      shebang-regex: 3.0.0
 
-  /shebang-regex/3.0.0:
+  shebang-regex@3.0.0:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
 
-  /signal-exit/4.1.0:
+  signal-exit@4.1.0:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
 
-  /source-map-js/1.2.1:
+  source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
 
-  /streamsearch/1.1.0:
+  streamsearch@1.1.0:
     resolution: {integrity: sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==}
     engines: {node: '>=10.0.0'}
-    dev: false
 
-  /string-width/4.2.3:
+  string-width@4.2.3:
     resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
     engines: {node: '>=8'}
-    dependencies:
-      emoji-regex: 8.0.0
-      is-fullwidth-code-point: 3.0.0
-      strip-ansi: 6.0.1
 
-  /string-width/5.1.2:
+  string-width@5.1.2:
     resolution: {integrity: sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==}
     engines: {node: '>=12'}
-    dependencies:
-      eastasianwidth: 0.2.0
-      emoji-regex: 9.2.2
-      strip-ansi: 7.1.2
 
-  /strip-ansi/6.0.1:
+  strip-ansi@6.0.1:
     resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
     engines: {node: '>=8'}
-    dependencies:
-      ansi-regex: 5.0.1
 
-  /strip-ansi/7.1.2:
+  strip-ansi@7.1.2:
     resolution: {integrity: sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==}
     engines: {node: '>=12'}
-    dependencies:
-      ansi-regex: 6.2.2
 
-  /styled-jsx/5.1.1_react@18.2.0:
+  styled-jsx@5.1.1:
     resolution: {integrity: sha512-pW7uC1l4mBZ8ugbiZrcIsiIvVx1UmTfw7UkC3Um2tmfUq9Bhk8IiyEIPl6F8agHgjzku6j0xQEZbfA5uSgSaCw==}
     engines: {node: '>= 12.0.0'}
     peerDependencies:
@@ -894,15 +639,577 @@ packages:
         optional: true
       babel-plugin-macros:
         optional: true
-    dependencies:
-      client-only: 0.0.1
-      react: 18.2.0
-    dev: false
 
-  /sucrase/3.35.0:
+  sucrase@3.35.0:
     resolution: {integrity: sha512-8EbVDiu9iN/nESwxeSxDKe0dunta1GOlHufmSSXxMD2z2/tMZpDMpvXQGsc+ajGo8y2uYUmixaSRUc/QPoQ0GA==}
     engines: {node: '>=16 || 14 >=14.17'}
     hasBin: true
+
+  supports-preserve-symlinks-flag@1.0.0:
+    resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
+    engines: {node: '>= 0.4'}
+
+  tailwind-merge@3.3.1:
+    resolution: {integrity: sha512-gBXpgUm/3rp1lMZZrM/w7D8GKqshif0zAymAhbCyIt8KMe+0v9DQ7cdYLR4FHH/cKpdTXb+A/tKKU3eolfsI+g==}
+
+  tailwindcss-animate@1.0.7:
+    resolution: {integrity: sha512-bl6mpH3T7I3UFxuvDEXLxy/VuFxBk5bbzplh7tXI68mwMokNYd1t9qPBHlnyTwfa4JGC4zP516I1hYYtQ/vspA==}
+    peerDependencies:
+      tailwindcss: '>=3.0.0 || insiders'
+
+  tailwindcss@3.4.18:
+    resolution: {integrity: sha512-6A2rnmW5xZMdw11LYjhcI5846rt9pbLSabY5XPxo+XWdxwZaFEn47Go4NzFiHu9sNNmr/kXivP1vStfvMaK1GQ==}
+    engines: {node: '>=14.0.0'}
+    hasBin: true
+
+  thenify-all@1.6.0:
+    resolution: {integrity: sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==}
+    engines: {node: '>=0.8'}
+
+  thenify@3.3.1:
+    resolution: {integrity: sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==}
+
+  to-regex-range@5.0.1:
+    resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
+    engines: {node: '>=8.0'}
+
+  ts-interface-checker@0.1.13:
+    resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
+
+  tslib@2.8.1:
+    resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
+  typescript@5.9.3:
+    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+  undici-types@7.13.0:
+    resolution: {integrity: sha512-Ov2Rr9Sx+fRgagJ5AX0qvItZG/JKKoBRAVITs1zk7IqZGTJUwgUr7qoYBpWwakpWilTZFM98rG/AFRocu10iIQ==}
+
+  update-browserslist-db@1.1.3:
+    resolution: {integrity: sha512-UxhIZQ+QInVdunkDAaiazvvT/+fXL5Osr0JZlJulepYu6Jd7qJtDZjlur0emRlT71EN3ScPoE7gvsuIKKNavKw==}
+    hasBin: true
+    peerDependencies:
+      browserslist: '>= 4.21.0'
+
+  util-deprecate@1.0.2:
+    resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
+
+  which@2.0.2:
+    resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
+    engines: {node: '>= 8'}
+    hasBin: true
+
+  wrap-ansi@7.0.0:
+    resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
+    engines: {node: '>=10'}
+
+  wrap-ansi@8.1.0:
+    resolution: {integrity: sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==}
+    engines: {node: '>=12'}
+
+snapshots:
+
+  '@alloc/quick-lru@5.2.0': {}
+
+  '@isaacs/cliui@8.0.2':
+    dependencies:
+      string-width: 5.1.2
+      string-width-cjs: string-width@4.2.3
+      strip-ansi: 7.1.2
+      strip-ansi-cjs: strip-ansi@6.0.1
+      wrap-ansi: 8.1.0
+      wrap-ansi-cjs: wrap-ansi@7.0.0
+
+  '@jridgewell/gen-mapping@0.3.13':
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+      '@jridgewell/trace-mapping': 0.3.31
+
+  '@jridgewell/resolve-uri@3.1.2': {}
+
+  '@jridgewell/sourcemap-codec@1.5.5': {}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.2
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  '@next/env@14.2.33': {}
+
+  '@next/swc-darwin-arm64@14.2.33':
+    optional: true
+
+  '@next/swc-darwin-x64@14.2.33':
+    optional: true
+
+  '@next/swc-linux-arm64-gnu@14.2.33':
+    optional: true
+
+  '@next/swc-linux-arm64-musl@14.2.33':
+    optional: true
+
+  '@next/swc-linux-x64-gnu@14.2.33':
+    optional: true
+
+  '@next/swc-linux-x64-musl@14.2.33':
+    optional: true
+
+  '@next/swc-win32-arm64-msvc@14.2.33':
+    optional: true
+
+  '@next/swc-win32-ia32-msvc@14.2.33':
+    optional: true
+
+  '@next/swc-win32-x64-msvc@14.2.33':
+    optional: true
+
+  '@nodelib/fs.scandir@2.1.5':
+    dependencies:
+      '@nodelib/fs.stat': 2.0.5
+      run-parallel: 1.2.0
+
+  '@nodelib/fs.stat@2.0.5': {}
+
+  '@nodelib/fs.walk@1.2.8':
+    dependencies:
+      '@nodelib/fs.scandir': 2.1.5
+      fastq: 1.19.1
+
+  '@pkgjs/parseargs@0.11.0':
+    optional: true
+
+  '@radix-ui/react-compose-refs@1.1.2(@types/react@19.2.0)(react@18.2.0)':
+    dependencies:
+      react: 18.2.0
+    optionalDependencies:
+      '@types/react': 19.2.0
+
+  '@radix-ui/react-slot@1.2.3(@types/react@19.2.0)(react@18.2.0)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.0)(react@18.2.0)
+      react: 18.2.0
+    optionalDependencies:
+      '@types/react': 19.2.0
+
+  '@swc/counter@0.1.3': {}
+
+  '@swc/helpers@0.5.5':
+    dependencies:
+      '@swc/counter': 0.1.3
+      tslib: 2.8.1
+
+  '@types/node@24.6.2':
+    dependencies:
+      undici-types: 7.13.0
+
+  '@types/react-dom@19.2.0(@types/react@19.2.0)':
+    dependencies:
+      '@types/react': 19.2.0
+
+  '@types/react@19.2.0':
+    dependencies:
+      csstype: 3.1.3
+
+  ansi-regex@5.0.1: {}
+
+  ansi-regex@6.2.2: {}
+
+  ansi-styles@4.3.0:
+    dependencies:
+      color-convert: 2.0.1
+
+  ansi-styles@6.2.3: {}
+
+  any-promise@1.3.0: {}
+
+  anymatch@3.1.3:
+    dependencies:
+      normalize-path: 3.0.0
+      picomatch: 2.3.1
+
+  arg@5.0.2: {}
+
+  autoprefixer@10.4.21(postcss@8.5.6):
+    dependencies:
+      browserslist: 4.26.3
+      caniuse-lite: 1.0.30001747
+      fraction.js: 4.3.7
+      normalize-range: 0.1.2
+      picocolors: 1.1.1
+      postcss: 8.5.6
+      postcss-value-parser: 4.2.0
+
+  balanced-match@1.0.2: {}
+
+  baseline-browser-mapping@2.8.12: {}
+
+  binary-extensions@2.3.0: {}
+
+  brace-expansion@2.0.2:
+    dependencies:
+      balanced-match: 1.0.2
+
+  braces@3.0.3:
+    dependencies:
+      fill-range: 7.1.1
+
+  browserslist@4.26.3:
+    dependencies:
+      baseline-browser-mapping: 2.8.12
+      caniuse-lite: 1.0.30001747
+      electron-to-chromium: 1.5.230
+      node-releases: 2.0.23
+      update-browserslist-db: 1.1.3(browserslist@4.26.3)
+
+  busboy@1.6.0:
+    dependencies:
+      streamsearch: 1.1.0
+
+  camelcase-css@2.0.1: {}
+
+  caniuse-lite@1.0.30001747: {}
+
+  chokidar@3.6.0:
+    dependencies:
+      anymatch: 3.1.3
+      braces: 3.0.3
+      glob-parent: 5.1.2
+      is-binary-path: 2.1.0
+      is-glob: 4.0.3
+      normalize-path: 3.0.0
+      readdirp: 3.6.0
+    optionalDependencies:
+      fsevents: 2.3.3
+
+  class-variance-authority@0.7.1:
+    dependencies:
+      clsx: 2.1.1
+
+  client-only@0.0.1: {}
+
+  clsx@2.1.1: {}
+
+  color-convert@2.0.1:
+    dependencies:
+      color-name: 1.1.4
+
+  color-name@1.1.4: {}
+
+  commander@4.1.1: {}
+
+  cross-spawn@7.0.6:
+    dependencies:
+      path-key: 3.1.1
+      shebang-command: 2.0.0
+      which: 2.0.2
+
+  cssesc@3.0.0: {}
+
+  csstype@3.1.3: {}
+
+  didyoumean@1.2.2: {}
+
+  dlv@1.1.3: {}
+
+  eastasianwidth@0.2.0: {}
+
+  electron-to-chromium@1.5.230: {}
+
+  emoji-regex@8.0.0: {}
+
+  emoji-regex@9.2.2: {}
+
+  escalade@3.2.0: {}
+
+  fast-glob@3.3.3:
+    dependencies:
+      '@nodelib/fs.stat': 2.0.5
+      '@nodelib/fs.walk': 1.2.8
+      glob-parent: 5.1.2
+      merge2: 1.4.1
+      micromatch: 4.0.8
+
+  fastq@1.19.1:
+    dependencies:
+      reusify: 1.1.0
+
+  fill-range@7.1.1:
+    dependencies:
+      to-regex-range: 5.0.1
+
+  foreground-child@3.3.1:
+    dependencies:
+      cross-spawn: 7.0.6
+      signal-exit: 4.1.0
+
+  fraction.js@4.3.7: {}
+
+  fsevents@2.3.3:
+    optional: true
+
+  function-bind@1.1.2: {}
+
+  glob-parent@5.1.2:
+    dependencies:
+      is-glob: 4.0.3
+
+  glob-parent@6.0.2:
+    dependencies:
+      is-glob: 4.0.3
+
+  glob@10.4.5:
+    dependencies:
+      foreground-child: 3.3.1
+      jackspeak: 3.4.3
+      minimatch: 9.0.5
+      minipass: 7.1.2
+      package-json-from-dist: 1.0.1
+      path-scurry: 1.11.1
+
+  graceful-fs@4.2.11: {}
+
+  hasown@2.0.2:
+    dependencies:
+      function-bind: 1.1.2
+
+  is-binary-path@2.1.0:
+    dependencies:
+      binary-extensions: 2.3.0
+
+  is-core-module@2.16.1:
+    dependencies:
+      hasown: 2.0.2
+
+  is-extglob@2.1.1: {}
+
+  is-fullwidth-code-point@3.0.0: {}
+
+  is-glob@4.0.3:
+    dependencies:
+      is-extglob: 2.1.1
+
+  is-number@7.0.0: {}
+
+  isexe@2.0.0: {}
+
+  jackspeak@3.4.3:
+    dependencies:
+      '@isaacs/cliui': 8.0.2
+    optionalDependencies:
+      '@pkgjs/parseargs': 0.11.0
+
+  jiti@1.21.7: {}
+
+  js-tokens@4.0.0: {}
+
+  lilconfig@3.1.3: {}
+
+  lines-and-columns@1.2.4: {}
+
+  loose-envify@1.4.0:
+    dependencies:
+      js-tokens: 4.0.0
+
+  lru-cache@10.4.3: {}
+
+  lucide-react@0.544.0(react@18.2.0):
+    dependencies:
+      react: 18.2.0
+
+  merge2@1.4.1: {}
+
+  micromatch@4.0.8:
+    dependencies:
+      braces: 3.0.3
+      picomatch: 2.3.1
+
+  minimatch@9.0.5:
+    dependencies:
+      brace-expansion: 2.0.2
+
+  minipass@7.1.2: {}
+
+  mz@2.7.0:
+    dependencies:
+      any-promise: 1.3.0
+      object-assign: 4.1.1
+      thenify-all: 1.6.0
+
+  nanoid@3.3.11: {}
+
+  next@14.2.33(react-dom@18.2.0(react@18.2.0))(react@18.2.0):
+    dependencies:
+      '@next/env': 14.2.33
+      '@swc/helpers': 0.5.5
+      busboy: 1.6.0
+      caniuse-lite: 1.0.30001747
+      graceful-fs: 4.2.11
+      postcss: 8.4.31
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+      styled-jsx: 5.1.1(react@18.2.0)
+    optionalDependencies:
+      '@next/swc-darwin-arm64': 14.2.33
+      '@next/swc-darwin-x64': 14.2.33
+      '@next/swc-linux-arm64-gnu': 14.2.33
+      '@next/swc-linux-arm64-musl': 14.2.33
+      '@next/swc-linux-x64-gnu': 14.2.33
+      '@next/swc-linux-x64-musl': 14.2.33
+      '@next/swc-win32-arm64-msvc': 14.2.33
+      '@next/swc-win32-ia32-msvc': 14.2.33
+      '@next/swc-win32-x64-msvc': 14.2.33
+    transitivePeerDependencies:
+      - '@babel/core'
+      - babel-plugin-macros
+
+  node-releases@2.0.23: {}
+
+  normalize-path@3.0.0: {}
+
+  normalize-range@0.1.2: {}
+
+  object-assign@4.1.1: {}
+
+  object-hash@3.0.0: {}
+
+  package-json-from-dist@1.0.1: {}
+
+  path-key@3.1.1: {}
+
+  path-parse@1.0.7: {}
+
+  path-scurry@1.11.1:
+    dependencies:
+      lru-cache: 10.4.3
+      minipass: 7.1.2
+
+  picocolors@1.1.1: {}
+
+  picomatch@2.3.1: {}
+
+  pify@2.3.0: {}
+
+  pirates@4.0.7: {}
+
+  postcss-import@15.1.0(postcss@8.5.6):
+    dependencies:
+      postcss: 8.5.6
+      postcss-value-parser: 4.2.0
+      read-cache: 1.0.0
+      resolve: 1.22.10
+
+  postcss-js@4.1.0(postcss@8.5.6):
+    dependencies:
+      camelcase-css: 2.0.1
+      postcss: 8.5.6
+
+  postcss-load-config@6.0.1(jiti@1.21.7)(postcss@8.5.6):
+    dependencies:
+      lilconfig: 3.1.3
+    optionalDependencies:
+      jiti: 1.21.7
+      postcss: 8.5.6
+
+  postcss-nested@6.2.0(postcss@8.5.6):
+    dependencies:
+      postcss: 8.5.6
+      postcss-selector-parser: 6.1.2
+
+  postcss-selector-parser@6.1.2:
+    dependencies:
+      cssesc: 3.0.0
+      util-deprecate: 1.0.2
+
+  postcss-value-parser@4.2.0: {}
+
+  postcss@8.4.31:
+    dependencies:
+      nanoid: 3.3.11
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
+  postcss@8.5.6:
+    dependencies:
+      nanoid: 3.3.11
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
+  queue-microtask@1.2.3: {}
+
+  react-dom@18.2.0(react@18.2.0):
+    dependencies:
+      loose-envify: 1.4.0
+      react: 18.2.0
+      scheduler: 0.23.2
+
+  react@18.2.0:
+    dependencies:
+      loose-envify: 1.4.0
+
+  read-cache@1.0.0:
+    dependencies:
+      pify: 2.3.0
+
+  readdirp@3.6.0:
+    dependencies:
+      picomatch: 2.3.1
+
+  resolve@1.22.10:
+    dependencies:
+      is-core-module: 2.16.1
+      path-parse: 1.0.7
+      supports-preserve-symlinks-flag: 1.0.0
+
+  reusify@1.1.0: {}
+
+  run-parallel@1.2.0:
+    dependencies:
+      queue-microtask: 1.2.3
+
+  scheduler@0.23.2:
+    dependencies:
+      loose-envify: 1.4.0
+
+  shebang-command@2.0.0:
+    dependencies:
+      shebang-regex: 3.0.0
+
+  shebang-regex@3.0.0: {}
+
+  signal-exit@4.1.0: {}
+
+  source-map-js@1.2.1: {}
+
+  streamsearch@1.1.0: {}
+
+  string-width@4.2.3:
+    dependencies:
+      emoji-regex: 8.0.0
+      is-fullwidth-code-point: 3.0.0
+      strip-ansi: 6.0.1
+
+  string-width@5.1.2:
+    dependencies:
+      eastasianwidth: 0.2.0
+      emoji-regex: 9.2.2
+      strip-ansi: 7.1.2
+
+  strip-ansi@6.0.1:
+    dependencies:
+      ansi-regex: 5.0.1
+
+  strip-ansi@7.1.2:
+    dependencies:
+      ansi-regex: 6.2.2
+
+  styled-jsx@5.1.1(react@18.2.0):
+    dependencies:
+      client-only: 0.0.1
+      react: 18.2.0
+
+  sucrase@3.35.0:
     dependencies:
       '@jridgewell/gen-mapping': 0.3.13
       commander: 4.1.1
@@ -912,26 +1219,15 @@ packages:
       pirates: 4.0.7
       ts-interface-checker: 0.1.13
 
-  /supports-preserve-symlinks-flag/1.0.0:
-    resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
-    engines: {node: '>= 0.4'}
+  supports-preserve-symlinks-flag@1.0.0: {}
 
-  /tailwind-merge/3.3.1:
-    resolution: {integrity: sha512-gBXpgUm/3rp1lMZZrM/w7D8GKqshif0zAymAhbCyIt8KMe+0v9DQ7cdYLR4FHH/cKpdTXb+A/tKKU3eolfsI+g==}
-    dev: false
+  tailwind-merge@3.3.1: {}
 
-  /tailwindcss-animate/1.0.7_tailwindcss@3.4.18:
-    resolution: {integrity: sha512-bl6mpH3T7I3UFxuvDEXLxy/VuFxBk5bbzplh7tXI68mwMokNYd1t9qPBHlnyTwfa4JGC4zP516I1hYYtQ/vspA==}
-    peerDependencies:
-      tailwindcss: '>=3.0.0 || insiders'
+  tailwindcss-animate@1.0.7(tailwindcss@3.4.18):
     dependencies:
       tailwindcss: 3.4.18
-    dev: false
 
-  /tailwindcss/3.4.18:
-    resolution: {integrity: sha512-6A2rnmW5xZMdw11LYjhcI5846rt9pbLSabY5XPxo+XWdxwZaFEn47Go4NzFiHu9sNNmr/kXivP1vStfvMaK1GQ==}
-    engines: {node: '>=14.0.0'}
-    hasBin: true
+  tailwindcss@3.4.18:
     dependencies:
       '@alloc/quick-lru': 5.2.0
       arg: 5.0.2
@@ -948,10 +1244,10 @@ packages:
       object-hash: 3.0.0
       picocolors: 1.1.1
       postcss: 8.5.6
-      postcss-import: 15.1.0_postcss@8.5.6
-      postcss-js: 4.1.0_postcss@8.5.6
-      postcss-load-config: 6.0.1_jiti@1.21.7+postcss@8.5.6
-      postcss-nested: 6.2.0_postcss@8.5.6
+      postcss-import: 15.1.0(postcss@8.5.6)
+      postcss-js: 4.1.0(postcss@8.5.6)
+      postcss-load-config: 6.0.1(jiti@1.21.7)(postcss@8.5.6)
+      postcss-nested: 6.2.0(postcss@8.5.6)
       postcss-selector-parser: 6.1.2
       resolve: 1.22.10
       sucrase: 3.35.0
@@ -959,72 +1255,45 @@ packages:
       - tsx
       - yaml
 
-  /thenify-all/1.6.0:
-    resolution: {integrity: sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==}
-    engines: {node: '>=0.8'}
+  thenify-all@1.6.0:
     dependencies:
       thenify: 3.3.1
 
-  /thenify/3.3.1:
-    resolution: {integrity: sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==}
+  thenify@3.3.1:
     dependencies:
       any-promise: 1.3.0
 
-  /to-regex-range/5.0.1:
-    resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
-    engines: {node: '>=8.0'}
+  to-regex-range@5.0.1:
     dependencies:
       is-number: 7.0.0
 
-  /ts-interface-checker/0.1.13:
-    resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
+  ts-interface-checker@0.1.13: {}
 
-  /tslib/2.8.1:
-    resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
-    dev: false
+  tslib@2.8.1: {}
 
-  /typescript/5.9.3:
-    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
-    engines: {node: '>=14.17'}
-    hasBin: true
-    dev: true
+  typescript@5.9.3: {}
 
-  /undici-types/7.13.0:
-    resolution: {integrity: sha512-Ov2Rr9Sx+fRgagJ5AX0qvItZG/JKKoBRAVITs1zk7IqZGTJUwgUr7qoYBpWwakpWilTZFM98rG/AFRocu10iIQ==}
-    dev: true
+  undici-types@7.13.0: {}
 
-  /update-browserslist-db/1.1.3_browserslist@4.26.3:
-    resolution: {integrity: sha512-UxhIZQ+QInVdunkDAaiazvvT/+fXL5Osr0JZlJulepYu6Jd7qJtDZjlur0emRlT71EN3ScPoE7gvsuIKKNavKw==}
-    hasBin: true
-    peerDependencies:
-      browserslist: '>= 4.21.0'
+  update-browserslist-db@1.1.3(browserslist@4.26.3):
     dependencies:
       browserslist: 4.26.3
       escalade: 3.2.0
       picocolors: 1.1.1
-    dev: true
 
-  /util-deprecate/1.0.2:
-    resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
+  util-deprecate@1.0.2: {}
 
-  /which/2.0.2:
-    resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
-    engines: {node: '>= 8'}
-    hasBin: true
+  which@2.0.2:
     dependencies:
       isexe: 2.0.0
 
-  /wrap-ansi/7.0.0:
-    resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
-    engines: {node: '>=10'}
+  wrap-ansi@7.0.0:
     dependencies:
       ansi-styles: 4.3.0
       string-width: 4.2.3
       strip-ansi: 6.0.1
 
-  /wrap-ansi/8.1.0:
-    resolution: {integrity: sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==}
-    engines: {node: '>=12'}
+  wrap-ansi@8.1.0:
     dependencies:
       ansi-styles: 6.2.3
       string-width: 5.1.2


### PR DESCRIPTION
## Summary
- add a data-driven /keyboards page with multiple mechanical keyboard layouts, OS toggle, and keypress highlighting
- expose the new page from the global navigation and home feature cards for easier discovery
- refresh the pnpm lockfile after installing dependencies for the build

## Testing
- pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68e200d7ccb0832c9ce56c9d5238335d