### PR TITLE
Fix keyboard layout wrapping on 100% layout

### DIFF
--- a/app/keyboards/page.tsx
+++ b/app/keyboards/page.tsx
@@ -1053,7 +1053,7 @@ const ArrowCluster = ({ isMac, pressedKeys }: { isMac: boolean; pressedKeys: Set
 
 const RowRenderer = ({ row, isMac, pressedKeys }: RowRendererProps) => {
   return (
-    <div className="flex flex-wrap items-center justify-center gap-1">
+    <div className="flex flex-nowrap items-center justify-center gap-1 overflow-x-auto pb-1">
       {row.map((item, index) => {
         if (item.kind === "gap") {
           return <div key={`gap-${index}`} className={gapClasses[item.size ?? "md"]} aria-hidden />;


### PR DESCRIPTION
## Summary
- prevent keyboard rows from wrapping by default so the 100% layout no longer breaks into multiple lines
- allow horizontal scrolling on smaller viewports to preserve readability without compressing the keycaps

## Testing
- pnpm lint *(fails: Command "lint" not found)*

------
https://chatgpt.com/codex/tasks/task_e_68e20a6222f4832cb77a51c6710d0969